### PR TITLE
Support for FaceFX Events

### DIFF
--- a/Source/FaceFX/Public/FaceFXConfig.h
+++ b/Source/FaceFX/Public/FaceFXConfig.h
@@ -87,6 +87,8 @@
     "FaceFX Sequencer support requires Unreal Engine 4.12 or higher. Please update your engine or use a previous version of the plugin.";
 #endif
 
+// Support for event notifiers coming from within the FaceFX runtime
+#define FFX_HAS_EVENTS (FFX_VERSION >= FFX_MAKE_VERSION(1,7,0))
 
 /** Blend mode for FaceFX runtime */
 UENUM()


### PR DESCRIPTION
- Support for events which are set within FaceFX studio and triggered by the FaceFX runtime during animation playback
- Toggable via IsIgnoreFaceFxEvents flag on the Blueprint setup node
- If enabled events are dispatched to the animation system and trigger anim/skeleton notifiers. They're also dispatched to user C++ callbacks
- Requires FaceFX runtime 1.7.0+